### PR TITLE
♻️ ✨ 募集一覧ページの見た目部分の実装。募集のコンポーネントへの分離。

### DIFF
--- a/src/app/(main)/recruits/page.tsx
+++ b/src/app/(main)/recruits/page.tsx
@@ -1,0 +1,70 @@
+import RecruitCard from "@/components/molecules/card/RecruitCard";
+import React from "react";
+
+const AllRecruits = () => {
+	return (
+		<div className="bg-slate-100 w-screen">
+			<div className="container max-w-[960px] mx-auto p-8 flex flex-col gap-8">
+				<h1 className="text-3xl font-bold">Recruits</h1>
+				<div className="grid grid-cols-2 gap-8">
+					<RecruitCard
+						title="ReactでSNSアプリを作りたい!"
+						description="
+								ReactでSNSアプリを作成したいです。具体的には、Reactで状態管理しつつwebsocketを活用してリアルタイム通信を行うことを想定しています。そして、、、、、、"
+						authorName="shadcn"
+						publishedAt="1日前"
+						goodCount={5}
+						remainingCount={3}
+					/>
+					<RecruitCard
+						title="ReactでSNSアプリを作りたい!"
+						description="
+								ReactでSNSアプリを作成したいです。具体的には、Reactで状態管理しつつwebsocketを活用してリアルタイム通信を行うことを想定しています。そして、、、、、、"
+						authorName="shadcn"
+						publishedAt="1日前"
+						goodCount={5}
+						remainingCount={3}
+					/>
+					<RecruitCard
+						title="ReactでSNSアプリを作りたい!"
+						description="
+								ReactでSNSアプリを作成したいです。具体的には、Reactで状態管理しつつwebsocketを活用してリアルタイム通信を行うことを想定しています。そして、、、、、、"
+						authorName="shadcn"
+						publishedAt="1日前"
+						goodCount={5}
+						remainingCount={3}
+					/>
+					<RecruitCard
+						title="ReactでSNSアプリを作りたい!"
+						description="
+								ReactでSNSアプリを作成したいです。具体的には、Reactで状態管理しつつwebsocketを活用してリアルタイム通信を行うことを想定しています。そして、、、、、、"
+						authorName="shadcn"
+						publishedAt="1日前"
+						goodCount={5}
+						remainingCount={3}
+					/>
+					<RecruitCard
+						title="ReactでSNSアプリを作りたい!"
+						description="
+								ReactでSNSアプリを作成したいです。具体的には、Reactで状態管理しつつwebsocketを活用してリアルタイム通信を行うことを想定しています。そして、、、、、、"
+						authorName="shadcn"
+						publishedAt="1日前"
+						goodCount={5}
+						remainingCount={3}
+					/>
+					<RecruitCard
+						title="ReactでSNSアプリを作りたい!"
+						description="
+								ReactでSNSアプリを作成したいです。具体的には、Reactで状態管理しつつwebsocketを活用してリアルタイム通信を行うことを想定しています。そして、、、、、、"
+						authorName="shadcn"
+						publishedAt="1日前"
+						goodCount={5}
+						remainingCount={3}
+					/>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default AllRecruits;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import Header from "@/components/organisms/header/Header";
 export default function Home() {
 	return (
 		<div className="">
-			{/* <Header /> */}
+			TOPページ
 		</div>
 	);
 }

--- a/src/components/molecules/card/RecruitCard.tsx
+++ b/src/components/molecules/card/RecruitCard.tsx
@@ -1,0 +1,75 @@
+import AvatarIcon from "@/components/atoms/avatar/AvatarIcon";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import Link from "next/link";
+import React from "react";
+
+const RecruitCard = ({
+	title,
+	description,
+	authorName,
+	publishedAt,
+	goodCount,
+	remainingCount,
+}: {
+    title: string;
+    description: string;
+    authorName: string;
+    publishedAt: string;
+    goodCount: number;
+    remainingCount: number;
+}) => {
+	return (
+		<Card className="shadow-none border-none">
+			<CardHeader>
+				<CardTitle className="truncate text-lg">
+					<Link href={"/recruits/1"} className="hover:opacity-70">
+						{title}
+					</Link>
+				</CardTitle>
+				<CardDescription className="truncate">
+                    {description}
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="flex gap-4">
+				<AvatarIcon
+					ImageSrc="https://github.com/shadcn.png"
+					fallbackText="アバター"
+				/>
+				<div>
+					<Link href={"/profiles/1"} className="hover:underline">
+						<p>{authorName}</p>
+					</Link>
+					<div className="flex justify-between gap-2 items-center">
+						<div className="text-sm text-slate-700">{publishedAt}</div>
+						<div className="flex items-center text-sm text-slate-700">
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								width="20"
+								height="20"
+								viewBox="0 0 24 24"
+							>
+								<path
+									fill="currentColor"
+									d="M12 4.528a6 6 0 0 0-8.243 8.715l6.829 6.828a2 2 0 0 0 2.828 0l6.829-6.828A6 6 0 0 0 12 4.528zm-1.172 1.644l.465.464a1 1 0 0 0 1.414 0l.465-.464a4 4 0 1 1 5.656 5.656L12 18.657l-6.828-6.829a4 4 0 0 1 5.656-5.656z"
+								/>
+							</svg>
+							{goodCount}
+						</div>
+						<p className="text-end text-xs text-slate-600 font-extralight">
+							あと{remainingCount}人募集中
+						</p>
+					</div>
+				</div>
+			</CardContent>
+			{/* <CardFooter></CardFooter> */}
+		</Card>
+	);
+};
+
+export default RecruitCard;

--- a/src/components/organisms/header/Header.tsx
+++ b/src/components/organisms/header/Header.tsx
@@ -17,58 +17,60 @@ const Header = () => {
 	console.log(session);
 
 	return (
-		<header className="container mx-auto lg:px-20 py-3">
-			<div className="flex justify-between items-center">
-				<div>
-					<Link href="/">
-						{/* svgにしたいな、WIX課金か？ */}
-						<Image src="/Preview.png" alt="logo" width={100} height={100} />
-					</Link>
-				</div>
-				<div className="flex items-center gap-4">
-					<Link href={"/search"}>
-						<SearchIcon className="hover:opacity-70 w-6 h-6 font-bold cursor-pointer" />
-					</Link>
-					{session ? (
-						<div className="flex items-center gap-4">
-							<AvatarIcon
-								className="cursor-pointer"
-								// 画像がundefinedの場合にダミー画像を出す
-								ImageSrc={session.user.image!}
-								fallbackText={session.user.name!}
-							/>
-							<MainButton className="rounded-full font-bold">
-								募集する
-							</MainButton>
-						</div>
-					) : (
-						<MainDialog
-							title="TechUnity"
-							description="TechUnityはチーム開発メンバーの募集をお手伝いする、チーム開発メンバー募集プラットフォームです。"
-							trigger={
+		<header className="border-b">
+			<div className="container mx-auto lg:px-20 py-3">
+				<div className="flex justify-between items-center">
+					<div>
+						<Link href="/">
+							{/* svgにしたいな、WIX課金か？ */}
+							<Image src="/Preview.png" alt="logo" width={100} height={100} />
+						</Link>
+					</div>
+					<div className="flex items-center gap-4">
+						<Link href={"/search"}>
+							<SearchIcon className="hover:opacity-70 w-6 h-6 font-bold cursor-pointer" />
+						</Link>
+						{session ? (
+							<div className="flex items-center gap-4">
+								<AvatarIcon
+									className="cursor-pointer"
+									// 画像がundefinedの場合にダミー画像を出す
+									ImageSrc={session.user.image!}
+									fallbackText={session.user.name!}
+								/>
 								<MainButton className="rounded-full font-bold">
-									ログイン
+									募集する
 								</MainButton>
-							}
-						>
-							<MainButton
-								className="rounded-full font-bold"
-								variant="outline"
-								onClick={() => signIn("github")}
+							</div>
+						) : (
+							<MainDialog
+								title="TechUnity"
+								description="TechUnityはチーム開発メンバーの募集をお手伝いする、チーム開発メンバー募集プラットフォームです。"
+								trigger={
+									<MainButton className="rounded-full font-bold">
+										ログイン
+									</MainButton>
+								}
 							>
-								<GitHubIcon />
-								GitHubでログイン
-							</MainButton>
-							<MainButton
-								className="rounded-full font-bold"
-								variant="outline"
-								onClick={() => signIn("google")}
-							>
-								<GoogleIcon />
-								Googleでログイン
-							</MainButton>
-						</MainDialog>
-					)}
+								<MainButton
+									className="rounded-full font-bold"
+									variant="outline"
+									onClick={() => signIn("github")}
+								>
+									<GitHubIcon />
+									GitHubでログイン
+								</MainButton>
+								<MainButton
+									className="rounded-full font-bold"
+									variant="outline"
+									onClick={() => signIn("google")}
+								>
+									<GoogleIcon />
+									Googleでログイン
+								</MainButton>
+							</MainDialog>
+						)}
+					</div>
 				</div>
 			</div>
 		</header>

--- a/src/components/organisms/recruits/RecruitList.tsx
+++ b/src/components/organisms/recruits/RecruitList.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const RecruitList = () => {
+    // APIたたいてrecruitsテーブルのレコードを全て取得してRecruitCardを使って表示する
+    // recruits.map((recruit) => <RecruitCard {...recruit} />)みたいな。
+  return (
+    <div>RecruitList</div>
+  )
+}
+
+export default RecruitList

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }


### PR DESCRIPTION
- 募集一覧ページの見た目部分を作成。
- 募集一覧ページで表示している、１件分の表示をCardコンポーネントに分離。

いずれCardListコンポーネント(Organisms)を作成して、その中でAPIをたたきRecruitデータを取得してCardに渡す方式にする。